### PR TITLE
Add calorie validation for food

### DIFF
--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -7,14 +7,29 @@ function all(){
 };
 
 function create(req) {
-  const food = req.body.food
-
-  return database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?, ?, ?) RETURNING id, name, calories',
-  [food.name, food.calories, new Date])
+  return new Promise( (resolve, reject) => {
+    const food = req.body.food
+    validation(food, (err) => {
+      if (err) {
+        return reject(err);
+      }
+      database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?, ?, ?) RETURNING id, name, calories',
+        [food.name, food.calories, new Date])
+          .then(resolve)
+          .catch(reject)
+    });
+  })
 }
 
 function destroy(req) {
   return database.raw('DELETE FROM foods WHERE id = ?', req.params.id)
+}
+
+function validation(food, callback) {
+  if (!food.calories) {
+    return callback(new Error('Food must have calories.'));
+  }
+  callback();
 }
 
 module.exports = {

--- a/test/food-test.js
+++ b/test/food-test.js
@@ -1,0 +1,16 @@
+const assert = require('chai').assert;
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+const Food = require('../lib/models/food');
+
+describe('Food', () => {
+  it('is invalid without calories', (done) => {
+    Food.create({name: 'banana', calories: null})
+      .catch( (err) => {
+        assert.equal(err.message, 'Food must have calories.')
+      })
+
+    done()
+  })
+})


### PR DESCRIPTION
This adds a model-level validation for food. I had to change our Food.create to return a promise even when there was an error. I image that to accommodate the name validation, we could add a conditional to the validation function. The rest of the logic should work for name as well, I think.

I also started a test file for the food model. 