### PR TITLE
Add name validation to food

### DIFF
--- a/lib/controllers/foods-controller.js
+++ b/lib/controllers/foods-controller.js
@@ -8,7 +8,7 @@ function index (req, res) {
 };
 
 function create (req, res) {
-  Food.create(req)
+  Food.create(req.body.food.name, req.body.food.calories)
     .then( (data) => {
       res.json(data.rows[0]);
     });

--- a/lib/models/food.js
+++ b/lib/models/food.js
@@ -6,17 +6,24 @@ function all(){
   return database.raw('SELECT * FROM foods')
 };
 
-function create(req) {
+function create(name, calories) {
   return new Promise( (resolve, reject) => {
-    const food = req.body.food
-    validation(food, (err) => {
+
+    calorieValidation(calories, (err) => {
       if (err) {
         return reject(err);
       }
-      database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?, ?, ?) RETURNING id, name, calories',
-        [food.name, food.calories, new Date])
-          .then(resolve)
-          .catch(reject)
+
+      nameValidation(name, (err) => {
+        if (err) {
+          return reject(err);
+        }
+
+        database.raw('INSERT INTO foods (name, calories, created_at) VALUES (?, ?, ?) RETURNING id, name, calories',
+          [name, calories, new Date])
+            .then(resolve)
+            .catch(reject)
+      })
     });
   })
 }
@@ -25,9 +32,16 @@ function destroy(req) {
   return database.raw('DELETE FROM foods WHERE id = ?', req.params.id)
 }
 
-function validation(food, callback) {
-  if (!food.calories) {
+function calorieValidation(calories, callback) {
+  if (!calories) {
     return callback(new Error('Food must have calories.'));
+  }
+  callback();
+}
+
+function nameValidation(name, callback) {
+  if (!name) {
+    return callback(new Error('Food must have name.'));
   }
   callback();
 }

--- a/test/food-test.js
+++ b/test/food-test.js
@@ -6,11 +6,20 @@ const Food = require('../lib/models/food');
 
 describe('Food', () => {
   it('is invalid without calories', (done) => {
-    Food.create({name: 'banana', calories: null})
+    Food.create('banana')
       .catch( (err) => {
         assert.equal(err.message, 'Food must have calories.')
       })
 
-    done()
+    done();
+  })
+
+  it('is invalid without name', (done) => {
+    Food.create(null, 40)
+      .catch( (err) => {
+        assert.equal(err.message, 'Food must have name.')
+      })
+
+    done();
   })
 })


### PR DESCRIPTION
This fixes the unhandled promise rejection warnings, and adds name validations for foods. Records are not made in the database, and an error is raised. Fully tested and refactored to the best of my ability at the moment.