### PR TITLE
Add date range to seed files, fix date interpolation in meal model

### DIFF
--- a/db/seeds/dev/categories.js
+++ b/db/seeds/dev/categories.js
@@ -5,19 +5,19 @@ exports.seed = function(knex, Promise) {
       return Promise.all([
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Breakfast", new Date]
+          ["breakfast", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Lunch", new Date]
+          ["lunch", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Dinner", new Date]
+          ["dinner", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Snacks", new Date]
+          ["snacks", new Date]
         ),
       ])
     })

--- a/db/seeds/dev/meals.js
+++ b/db/seeds/dev/meals.js
@@ -5,15 +5,66 @@ exports.seed = function(knex, Promise) {
         knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
           [new Date, 1, 3, new Date]
-        ,
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
           [new Date, 2, 3, new Date]
-        ,
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
           [new Date, 3, 3, new Date]
-        ,
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
           [new Date, 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 4, 3, new Date]
         )
       ])
     })

--- a/db/seeds/production/categories.js
+++ b/db/seeds/production/categories.js
@@ -5,19 +5,19 @@ exports.seed = function(knex, Promise) {
       return Promise.all([
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Breakfast", new Date]
+          ["breakfast", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Lunch", new Date]
+          ["lunch", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Dinner", new Date]
+          ["dinner", new Date]
         ),
         knex.raw(
           'INSERT INTO categories (name, created_at) VALUES (?, ?)',
-          ["Snacks", new Date]
+          ["snacks", new Date]
         ),
       ])
     })

--- a/db/seeds/production/meals.js
+++ b/db/seeds/production/meals.js
@@ -4,16 +4,67 @@ exports.seed = function(knex, Promise) {
       return Promise.all([
         knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
-          [new Date, 1, 3, new Date]
-        ,
+          [new Date(2017, 04, 11), 1, 3, new Date]
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
-          [new Date, 2, 3, new Date]
-        ,
+          [new Date(2017, 04, 11), 2, 3, new Date]
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
-          [new Date, 3, 3, new Date]
-        ,
+          [new Date(2017, 04, 11), 3, 3, new Date]
+        ),
+        knex.raw(
           'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
-          [new Date, 4, 3, new Date]
+          [new Date(2017, 04, 11), 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 10), 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 12), 4, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 1, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 2, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 3, 3, new Date]
+        ),
+        knex.raw(
+          'INSERT INTO meals (date, category_id, food_id, created_at) VALUES (?, ?, ?, ?)',
+          [new Date(2017, 04, 13), 4, 3, new Date]
         )
       ])
     })

--- a/lib/models/meal.js
+++ b/lib/models/meal.js
@@ -11,7 +11,7 @@ class Meal {
                          JOIN categories ON category_id = categories.id
                          JOIN foods ON food_id = foods.id
                          WHERE date = ? AND categories.name = ?`,
-      [date.toLocaleDateString(), category])
+      [`${date.getFullYear()}/${date.getMonth()}/${date.getDate()}`, category])
   }
 
 }


### PR DESCRIPTION
I added extra dates to the seed file so that I could test a range of dates with my requests. I also had to lowercase the category names in the seed file because it was causing a mismatch from the params, and it made more sense to me to have the url be lowercase.

I also had to fix the date in the meal model because it wasn't matching right when the date came through the params. It wasn't causing an error, but the date was in the wrong order and it was returning an empty array. That took me much longer to fix than I would care to admit.