### PR TITLE
Update endpoint to insert multiple entries to a meal

### DIFF
--- a/lib/controllers/meals-controller.js
+++ b/lib/controllers/meals-controller.js
@@ -17,7 +17,7 @@ class MealsController {
   create(req, res) {
     Meal.create(req.body.meal)
     .then((data) => {
-      res.json(data.rows[0])
+      res.json(data)
     })
   }
 }

--- a/lib/models/meal.js
+++ b/lib/models/meal.js
@@ -1,6 +1,7 @@
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../knexfile')[environment];
 const database = require('knex')(configuration);
+const async = require('async');
 
 class Meal {
 
@@ -15,20 +16,39 @@ class Meal {
   }
 
   static create(mealAttrs) {
-    return database.raw(`SELECT * FROM categories WHERE name = ?`, mealAttrs.category)
-    .then((data) => {
-      let categoryID = data.rows[0].id;
-      return database.raw(`INSERT INTO meals(date, category_id, food_id)
-                           VALUES (?, ?, ?)
-                           RETURNING *`,
-                           [mealAttrs.date, categoryID, mealAttrs.foodID])
-    }).then((data) => {
-      return database.raw(`SELECT meals.*, categories.name AS category
-                           FROM meals
-                           JOIN categories ON category_id = categories.id
-                           WHERE meals.id = ?`,
-                           [data.rows[0].id])
+    let foodIds = mealAttrs.foodIds.split(',');
+
+    return new Promise((resolve, reject) => {
+      let foods = []
+      async.each(foodIds, (foodId, done) => {
+        database.raw(`SELECT * FROM categories WHERE name = ?`, mealAttrs.category)
+        .then((data) => {
+          let categoryID = data.rows[0].id;
+          return database.raw(`INSERT INTO meals(date, category_id, food_id)
+                               VALUES (?, ?, ?)
+                               RETURNING *`,
+                               [mealAttrs.date, categoryID, foodId])
+        }).then((data) => {
+          return database.raw(`SELECT meals.*, categories.name AS category
+                               FROM meals
+                               JOIN categories ON category_id = categories.id
+                               WHERE meals.id = ?`,
+                               [data.rows[0].id])
+        }).then((data) => {
+          foods.push(data.rows[0])
+          done();
+        }).catch(done)
+      }, (err) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(foods)
+      })
     })
+  }
+
+  insertMeal() {
+
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "request": "^2.81.0"
   },
   "dependencies": {
+    "async": "^2.4.0",
     "body-parser": "^1.17.1",
     "express": "^4.15.2",
     "knex": "^0.13.0",

--- a/test/meals-response-test.js
+++ b/test/meals-response-test.js
@@ -233,7 +233,10 @@ describe('Server', () => {
       beforeEach((done) => {
         food.create('paella', 2000)
         .then((data) => {
-          this.food = data.rows[0];
+          this.foods = [data.rows[0]]
+          return food.create('muffin', 900)
+        }).then((data) => {
+          this.foods.push(data.rows[0])
           return database.raw(
             'INSERT INTO categories (name, created_at) VALUES (?, ?) RETURNING *',
             ['breakfast', new Date])
@@ -247,7 +250,9 @@ describe('Server', () => {
 
       it('should return 200', (done) => {
         let meal = {
-          foodID: this.food.id,
+          foodIds: this.foods.map((food) => {
+            return food.id
+          }).join(','),
           category: 'breakfast',
           date: '2017/5/15'
         }
@@ -255,12 +260,13 @@ describe('Server', () => {
         this.request.post('api/meals', { form: {meal: meal} }, (err, res) => {
           if (err) { return done(err) }
 
-          let parsedMeal = JSON.parse(res.body);
-          let parsedDate = new Date(parsedMeal.date);
+          let parsedMeals = JSON.parse(res.body);
+          let parsedDate = new Date(parsedMeals[0].date);
 
           assert.equal(res.statusCode, 200);
-          assert.equal(parsedMeal.food_id, this.food.id)
-          assert.equal(parsedMeal.category, 'breakfast')
+          assert.equal(parsedMeals.length, 2);
+          assert.equal(parsedMeals[0].food_id, this.foods[0].id)
+          assert.equal(parsedMeals[0].category, 'breakfast')
           assert.equal(parsedDate.getFullYear(), '2017')
           assert.equal(parsedDate.getMonth(), '4')
           assert.equal(parsedDate.getDate(), '15')


### PR DESCRIPTION
I realized that because there is a checklist of foods on the front end, I needed to make sure this endpoint you accepted multiple foods at once and created an entry for each food. I added the async library because I don't think you can iterate through promises the way we're used to. The async call makes sure that each loop calls its callback successfully. If it throws an error, it exits the loop.